### PR TITLE
fix(solutions): resolve tslearn/numba incompatibility by pinning version

### DIFF
--- a/solutions/causal-impact/CausalImpact_with_Experimental_Design.ipynb
+++ b/solutions/causal-impact/CausalImpact_with_Experimental_Design.ipynb
@@ -41,7 +41,7 @@
         "if 'fastdtw' not in sys.modules:\n",
         "  !pip install 'fastdtw' --q\n",
         "if 'tslearn' not in sys.modules:\n",
-        "  !pip install 'tslearn' --q\n",
+        "  !pip install 'tslearn==0.7.0' --q\n",
         "if 'tfp-causalimpact' not in sys.modules:\n",
         "  !pip install 'tfp-causalimpact' --q\n",
         "\n",


### PR DESCRIPTION
The latest release of `tslearn` (0.8.0) introduced a regression when used with recent versions of `numba` (0.60.0+) and `numpy` (2.0.2), causing a `NumbaTypeError: float() only support for numbers` during the execution of DTW-based clustering functions.

This PR updates the installation command in the `CausalImpact_with_Experimental_Design.ipynb` notebook to pin `tslearn` to version `0.7.0`. This version has been verified to work correctly in the current environment, resolving the runtime error reported by the user.

No other code changes were necessary as this is strictly a dependency version compatibility fix.

---
*PR created automatically by Jules for task [17866619168667236984](https://jules.google.com/task/17866619168667236984) started by @rhirota*